### PR TITLE
dbus Method Error Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,9 +340,10 @@ dependencies = [
 
 [[package]]
 name = "iwdrs"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
- "anyhow",
+ "strum",
+ "thiserror",
  "uuid",
  "zbus",
  "zvariant",
@@ -572,6 +573,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +615,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iwdrs"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 description = "Rust cratte for iwd"
@@ -11,5 +11,6 @@ repository = "https://github.com/pythops/iwdrs"
 [dependencies]
 zbus = "5"
 zvariant = "5"
-anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
+thiserror = "2.0.17"
+strum = {version = "0.27.2", features = ["derive"]}

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
 use std::sync::Arc;
 
-use zbus::{Connection, Proxy};
+use zbus::{Connection, Proxy, Result};
 use zvariant::OwnedObjectPath;
 
 #[derive(Clone, Debug)]
@@ -18,7 +17,7 @@ impl Adapter {
         }
     }
 
-    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>, zbus::Error> {
+    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>> {
         Proxy::new(
             &self.connection,
             "net.connman.iwd",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use zbus::{Connection, Proxy, interface};
@@ -30,7 +29,7 @@ impl AgentManager {
         .await
     }
 
-    pub(crate) async fn register_agent(&self, agent: Agent) -> Result<()> {
+    pub(crate) async fn register_agent(&self, agent: Agent) -> zbus::Result<()> {
         let proxy = self.proxy().await?;
         proxy
             .call_method("RegisterAgent", &(self.dbus_path))

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,9 +1,8 @@
-use anyhow::{Ok, Result};
 use std::sync::Arc;
 
 use zvariant::OwnedObjectPath;
 
-use zbus::{Connection, Proxy};
+use zbus::{Connection, Proxy, Result};
 
 use crate::{adapter::Adapter, modes::Mode};
 
@@ -21,7 +20,7 @@ impl Device {
         }
     }
 
-    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>, zbus::Error> {
+    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>> {
         Proxy::new(
             &self.connection,
             "net.connman.iwd",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,36 @@
+use strum::EnumMessage;
+use thiserror::Error;
+
+pub mod access_point;
+pub mod network;
+pub mod station;
+
+pub type Result<T, E> = std::result::Result<T, IWDError<E>>;
+
+#[derive(Debug, Error)]
+pub enum IWDError<T: std::str::FromStr + std::error::Error> {
+    OperationError(T),
+    ZbusError(zbus::Error),
+}
+
+impl<T: std::str::FromStr<Err = strum::ParseError> + std::error::Error + EnumMessage>
+    From<zbus::Error> for IWDError<T>
+{
+    fn from(value: zbus::Error) -> Self {
+        let zbus::Error::MethodError(error_name, _error_description, _) = &value else {
+            return Self::ZbusError(value);
+        };
+        match T::from_str(error_name.as_str()) {
+            Ok(error) => {
+                debug_assert!(
+                    _error_description
+                        .as_ref()
+                        .is_some_and(|err| err.as_str() == error.get_detailed_message().unwrap())
+                );
+
+                Self::OperationError(error)
+            }
+            Err(_) => Self::ZbusError(value),
+        }
+    }
+}

--- a/src/error/access_point.rs
+++ b/src/error/access_point.rs
@@ -1,0 +1,134 @@
+use std::fmt::Display;
+
+use strum::{EnumMessage, EnumString};
+use thiserror::Error;
+
+#[derive(Debug, EnumString, EnumMessage, Error)]
+pub enum AccessPointStartError {
+    #[strum(
+        serialize = "net.connman.iwd.Failed",
+        message = "Failed",
+        detailed_message = "Operation failed"
+    )]
+    Failed,
+    #[strum(
+        serialize = "net.connman.iwd.InvalidArguments",
+        message = "InvalidArguments",
+        detailed_message = "Argument type is wrong"
+    )]
+    InvalidArguments,
+    #[strum(
+        serialize = "net.connman.iwd.AlreadyExists",
+        message = "AlreadyExists",
+        detailed_message = "Object already exists"
+    )]
+    AlreadyExists,
+}
+
+impl Display for AccessPointStartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_detailed_message().unwrap())
+    }
+}
+
+#[derive(Debug, EnumString, EnumMessage, Error)]
+pub enum AccessPointStopError {
+    #[strum(
+        serialize = "net.connman.iwd.Busy",
+        message = "InProgress",
+        detailed_message = "Operation already in progress"
+    )]
+    Busy,
+    #[strum(
+        serialize = "net.connman.iwd.Failed",
+        message = "Failed",
+        detailed_message = "Operation failed"
+    )]
+    Failed,
+    #[strum(
+        serialize = "net.connman.iwd.InvalidArguments",
+        message = "InvalidArguments",
+        detailed_message = "Argument type is wrong"
+    )]
+    InvalidArguments,
+}
+
+impl Display for AccessPointStopError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_detailed_message().unwrap())
+    }
+}
+
+#[derive(Debug, EnumString, EnumMessage, Error)]
+pub enum StartProfileError {
+    #[strum(
+        serialize = "net.connman.iwd.Busy",
+        message = "InProgress",
+        detailed_message = "Operation already in progress"
+    )]
+    Busy,
+    #[strum(
+        serialize = "net.connman.iwd.Failed",
+        message = "Failed",
+        detailed_message = "Operation failed"
+    )]
+    Failed,
+    #[strum(
+        serialize = "net.connman.iwd.InvalidArguments",
+        message = "InvalidArguments",
+        detailed_message = "Argument type is wrong"
+    )]
+    InvalidArguments,
+    #[strum(
+        serialize = "net.connman.iwd.AlreadyExists",
+        message = "AlreadyExists",
+        detailed_message = "Object already exists"
+    )]
+    AlreadyExists,
+    #[strum(
+        serialize = "net.connman.iwd.NotFound",
+        message = "NotFound",
+        detailed_message = "Object not found"
+    )]
+    NotFound,
+}
+
+impl Display for StartProfileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_detailed_message().unwrap())
+    }
+}
+
+#[derive(Debug, EnumString, EnumMessage, Error)]
+pub enum ScanError {
+    #[strum(
+        serialize = "net.connman.iwd.NotAvailable",
+        message = "NotAvailable",
+        detailed_message = "Operation not available"
+    )]
+    NotAvailable,
+    #[strum(
+        serialize = "net.connman.iwd.NotSupported",
+        message = "NotSupported",
+        detailed_message = "Operation not supported"
+    )]
+    NotSupported,
+    #[strum(
+        serialize = "net.connman.iwd.Busy",
+        message = "InProgress",
+        detailed_message = "Operation already in progress"
+    )]
+    Busy,
+    #[strum(
+        serialize = "net.connman.iwd.Failed",
+        message = "Failed",
+        detailed_message = "Operation failed"
+    )]
+    Failed,
+}
+
+impl Display for ScanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_detailed_message().unwrap())
+    }
+}

--- a/src/error/network.rs
+++ b/src/error/network.rs
@@ -1,0 +1,62 @@
+use std::fmt::Display;
+
+use strum::{EnumMessage, EnumString};
+use thiserror::Error;
+
+#[derive(Debug, EnumString, EnumMessage, Error)]
+pub enum ConnectError {
+    #[strum(
+        serialize = "net.connman.iwd.Aborted",
+        message = "Aborted",
+        detailed_message = "Operation aborted"
+    )]
+    Aborted,
+    #[strum(
+        serialize = "net.connman.iwd.Busy",
+        message = "InProgress",
+        detailed_message = "Operation already in progress"
+    )]
+    Busy,
+    #[strum(
+        serialize = "net.connman.iwd.Failed",
+        message = "Failed",
+        detailed_message = "Operation failed"
+    )]
+    Failed,
+    #[strum(
+        serialize = "net.connman.iwd.NoAgent",
+        message = "NoAgent",
+        detailed_message = "No Agent registered"
+    )]
+    NoAgent,
+    #[strum(
+        serialize = "net.connman.iwd.NotSupported",
+        message = "NotSupported",
+        detailed_message = "Operation not supported"
+    )]
+    NotSupported,
+    #[strum(
+        serialize = "net.connman.iwd.InProgress",
+        message = "InProgress",
+        detailed_message = "Operation already in progress"
+    )]
+    InProgress,
+    #[strum(
+        serialize = "net.connman.iwd.NotConfigured",
+        message = "NotConfigured",
+        detailed_message = "Not configured"
+    )]
+    NotConfigured,
+    #[strum(
+        serialize = "net.connman.iwd.InvalidFormat",
+        message = "InvalidFormat",
+        detailed_message = "Argument format is invalid"
+    )]
+    InvalidFormat,
+}
+
+impl Display for ConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_detailed_message().unwrap())
+    }
+}

--- a/src/error/station.rs
+++ b/src/error/station.rs
@@ -1,0 +1,54 @@
+use std::fmt::Display;
+
+use strum::{EnumMessage, EnumString};
+use thiserror::Error;
+
+#[derive(Debug, EnumString, EnumMessage, Error)]
+pub enum ScanError {
+    #[strum(
+        serialize = "net.connman.iwd.Busy",
+        message = "InProgress",
+        detailed_message = "Operation already in progress"
+    )]
+    Busy,
+    #[strum(
+        serialize = "net.connman.iwd.Failed",
+        message = "Failed",
+        detailed_message = "Operation failed"
+    )]
+    Failed,
+}
+
+impl Display for ScanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_detailed_message().unwrap())
+    }
+}
+
+#[derive(Debug, EnumString, EnumMessage, Error)]
+pub enum DisconnectError {
+    #[strum(
+        serialize = "net.connman.iwd.Busy",
+        message = "InProgress",
+        detailed_message = "Operation already in progress"
+    )]
+    Busy,
+    #[strum(
+        serialize = "net.connman.iwd.Failed",
+        message = "Failed",
+        detailed_message = "Operation failed"
+    )]
+    Failed,
+    #[strum(
+        serialize = "net.connman.iwd.NotConnected",
+        message = "NotConnected",
+        detailed_message = "Not connected"
+    )]
+    NotConnected,
+}
+
+impl Display for DisconnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_detailed_message().unwrap())
+    }
+}

--- a/src/known_netowk.rs
+++ b/src/known_netowk.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
 use std::sync::Arc;
 
-use zbus::{Connection, Proxy};
+use zbus::{Connection, Proxy, Result};
 use zvariant::OwnedObjectPath;
 
 #[derive(Clone, Debug)]
@@ -18,7 +17,7 @@ impl KnownNetwork {
         }
     }
 
-    async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>, zbus::Error> {
+    async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>> {
         Proxy::new(
             &self.connection,
             "net.connman.iwd",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,5 @@ pub mod known_netowk;
 pub mod access_point;
 
 pub mod modes;
+
+pub mod error;

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,10 +1,13 @@
-use anyhow::Result;
 use std::sync::Arc;
 
-use zbus::{Connection, Proxy};
+use zbus::{Connection, Proxy, Result as ZbusResult};
 use zvariant::OwnedObjectPath;
 
-use crate::{device::Device, known_netowk::KnownNetwork};
+use crate::{
+    device::Device,
+    error::{IWDError, network::ConnectError},
+    known_netowk::KnownNetwork,
+};
 
 #[derive(Clone, Debug)]
 pub struct Network {
@@ -31,7 +34,7 @@ impl Network {
     }
 
     // Methods
-    pub async fn connect(&self) -> Result<()> {
+    pub async fn connect(&self) -> Result<(), IWDError<ConnectError>> {
         let proxy = self.proxy().await?;
         proxy.call_method("Connect", &()).await?;
         Ok(())
@@ -39,19 +42,19 @@ impl Network {
 
     // Properties
 
-    pub async fn name(&self) -> Result<String> {
+    pub async fn name(&self) -> ZbusResult<String> {
         let proxy = self.proxy().await?;
         let name: String = proxy.get_property("Name").await?;
         Ok(name)
     }
 
-    pub async fn connected(&self) -> Result<bool> {
+    pub async fn connected(&self) -> ZbusResult<bool> {
         let proxy = self.proxy().await?;
         let is_connected: bool = proxy.get_property("Connected").await?;
         Ok(is_connected)
     }
 
-    pub async fn device(&self) -> Result<Device> {
+    pub async fn device(&self) -> ZbusResult<Device> {
         let proxy = self.proxy().await?;
         let device_path: OwnedObjectPath = proxy.get_property("Device").await?;
 
@@ -59,13 +62,13 @@ impl Network {
         Ok(device)
     }
 
-    pub async fn network_type(&self) -> Result<String> {
+    pub async fn network_type(&self) -> ZbusResult<String> {
         let proxy = self.proxy().await?;
         let network_type: String = proxy.get_property("Type").await?;
         Ok(network_type)
     }
 
-    pub async fn known_network(&self) -> Result<Option<KnownNetwork>> {
+    pub async fn known_network(&self) -> ZbusResult<Option<KnownNetwork>> {
         let proxy = self.proxy().await?;
         if let Ok(known_network_path) = proxy.get_property::<OwnedObjectPath>("KnownNetwork").await
         {

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,6 @@ use crate::{
     known_netowk::KnownNetwork,
     station::{Station, StationDiagnostics},
 };
-use anyhow::Result;
 use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 use zbus::{Connection, Proxy};
@@ -19,7 +18,7 @@ pub struct Session {
 }
 
 impl Session {
-    pub async fn new() -> Result<Self> {
+    pub async fn new() -> zbus::Result<Self> {
         let connection = Arc::new(Connection::system().await?);
 
         let proxy = Proxy::new(
@@ -115,7 +114,7 @@ impl Session {
             .collect()
     }
 
-    pub async fn register_agent(&self, agent: Agent) -> Result<AgentManager> {
+    pub async fn register_agent(&self, agent: Agent) -> zbus::Result<AgentManager> {
         let path =
             OwnedObjectPath::try_from(format!("/iwdrs/agent/{}", Uuid::new_v4().as_simple()))?;
         let agent_manager = AgentManager::new(self.connection.clone(), path);


### PR DESCRIPTION
Makes all method return a method specific error type instead of `anyhow::Error` this allows users of this library to programmatically handle errors.

Errors returned by each method are taken from iwd dbus docs.

This is backwards-incompatible, so I have bumped the version in `Cargo.toml`.

# Testing
Errors types seem to work as expected. I have been testing using (https://github.com/abezukor/iwdrs/blob/abe/connect_network_example/examples/connect_network.rs). I plan to open a seperate pr to merge that example.