### PR TITLE
Agent Trait and SignalLevelAgent

### DIFF
--- a/examples/monitor_signal_strength.rs
+++ b/examples/monitor_signal_strength.rs
@@ -1,0 +1,41 @@
+use clap::Parser;
+use iwdrs::station::SignalLevelAgent;
+
+#[derive(Debug, Parser)]
+/// Connect to a Wifi Network given a SSID and optionally a password.
+struct Args {
+    #[clap(allow_hyphen_values = true)]
+    levels: Vec<i16>,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let Args { levels } = Args::parse();
+
+    let session = iwdrs::session::Session::new().await.unwrap();
+
+    let station = session.stations().pop().unwrap();
+
+    station
+        .register_signal_level_agent(levels, Agent {})
+        .await
+        .unwrap();
+
+    std::future::pending::<()>().await;
+}
+
+struct Agent {}
+
+impl SignalLevelAgent for Agent {
+    fn changed(
+        &self,
+        _station: &iwdrs::station::Station,
+        signal_level: impl std::ops::RangeBounds<i16>,
+    ) {
+        println!(
+            "Wifi Signal Strength Min {:?} Max {:?}",
+            signal_level.start_bound(),
+            signal_level.end_bound()
+        )
+    }
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,7 +1,10 @@
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{future::Future, str::FromStr, sync::Arc};
 
+use strum::EnumString;
 use zbus::{Connection, Proxy, interface};
 use zvariant::OwnedObjectPath;
+
+use crate::{error::agent::Canceled, network::Network};
 
 // AgentManager
 
@@ -29,43 +32,141 @@ impl AgentManager {
         .await
     }
 
-    pub(crate) async fn register_agent(&self, agent: Agent) -> zbus::Result<()> {
+    pub(crate) async fn register_agent(&self, agent: impl Agent) -> zbus::Result<()> {
         let proxy = self.proxy().await?;
         proxy
             .call_method("RegisterAgent", &(self.dbus_path))
             .await?;
 
+        let interface = AgentInterface {
+            agent,
+            connection: self.connection.clone(),
+        };
+
         self.connection
             .object_server()
-            .at(self.dbus_path.clone(), agent)
+            .at(self.dbus_path.clone(), interface)
             .await?;
 
         Ok(())
     }
 }
 
-// Agent
+#[derive(Debug, EnumString)]
+pub enum CancellationReason {
+    #[strum(serialize = "out-of-range")]
+    OutOfRange,
+    #[strum(serialize = "user-canceled")]
+    UserCanceled,
+    #[strum(serialize = "timed-out")]
+    Timeout,
+    #[strum(serialize = "shutdown")]
+    Shutdown,
+}
 
-pub type RequestPassPhraseFn = Box<
-    dyn (Fn() -> Pin<Box<dyn Future<Output = Result<String, Box<dyn std::error::Error>>> + Send>>)
-        + Send
-        + Sync,
->;
+pub trait Agent: Send + Sync + 'static {
+    /// This method gets called when the service daemon unregisters the agent. An agent can use it to do
+    /// cleanup tasks. There is no need to unregister the agent, because when this method gets called it has
+    /// already been unregistered.
+    fn release(&self) {}
 
-pub struct Agent {
-    pub request_passphrase_fn: RequestPassPhraseFn,
+    ///This method gets called when trying to connect to a network and passphrase is required.
+    fn request_passphrase(
+        &self,
+        network: &Network,
+    ) -> impl Future<Output = Result<String, Canceled>> + Send;
+
+    /// This method gets called when connecting to a network that requires authentication using a
+    /// locally-stored encrypted private key file, to obtain that private key's encryption passphrase.
+    fn request_private_key_passphrase(
+        &self,
+        network: &Network,
+    ) -> impl Future<Output = Result<String, Canceled>> + Send;
+
+    /// This method gets called when connecting to a network that requires authentication using a
+    /// user name and password.
+    fn request_user_name_and_passphrase(
+        &self,
+        network: &Network,
+    ) -> impl Future<Output = Result<(String, String), Canceled>> + Send;
+
+    /// This method gets called when connecting to a network that requires authentication with a
+    /// user password.  The user name is optionally passed in the parameter.
+    fn request_user_password(
+        &self,
+        network: &Network,
+        user_name: Option<&String>,
+    ) -> impl Future<Output = Result<(String, String), Canceled>> + Send;
+
+    /// This method gets called to indicate that the agent request failed before a reply was returned.
+    fn cancel(&self, _reason: CancellationReason) {}
+}
+
+struct AgentInterface<A> {
+    agent: A,
+    connection: Arc<Connection>,
+}
+
+impl<A> AgentInterface<A> {
+    fn get_network(&self, network_path: OwnedObjectPath) -> Network {
+        Network {
+            connection: self.connection.clone(),
+            dbus_path: network_path,
+        }
+    }
 }
 
 #[interface(name = "net.connman.iwd.Agent")]
-impl Agent {
+impl<A: Agent> AgentInterface<A> {
+    #[zbus(name = "Release")]
+    fn release(&self) {
+        self.agent.release();
+    }
+
     #[zbus(name = "RequestPassphrase")]
-    async fn request_passphrase(
+    async fn request_passphrase(&self, network_path: OwnedObjectPath) -> zbus::fdo::Result<String> {
+        let network = self.get_network(network_path);
+        Ok(self.agent.request_passphrase(&network).await?)
+    }
+
+    #[zbus(name = "RequestPrivateKeyPassphrase")]
+    async fn request_private_key_passphrase(
         &self,
-        _network_path: OwnedObjectPath,
+        network_path: OwnedObjectPath,
     ) -> zbus::fdo::Result<String> {
-        match (self.request_passphrase_fn)().await {
-            Ok(passphrase) => Ok(passphrase),
-            Err(e) => Err(zbus::fdo::Error::Failed(e.to_string())),
-        }
+        let network = self.get_network(network_path);
+        Ok(self.agent.request_private_key_passphrase(&network).await?)
+    }
+
+    #[zbus(name = "RequestUserNameAndPassword")]
+    async fn request_user_name_and_passphrase(
+        &self,
+        network_path: OwnedObjectPath,
+    ) -> zbus::fdo::Result<(String, String)> {
+        let network = self.get_network(network_path);
+        Ok(self
+            .agent
+            .request_user_name_and_passphrase(&network)
+            .await?)
+    }
+
+    #[zbus(name = "RequestUserPassword")]
+    async fn request_user_password(
+        &self,
+        network_path: OwnedObjectPath,
+        user_name: zvariant::Optional<String>,
+    ) -> zbus::fdo::Result<(String, String)> {
+        let network = self.get_network(network_path);
+        let user_name = user_name.as_ref();
+        Ok(self
+            .agent
+            .request_user_password(&network, user_name)
+            .await?)
+    }
+
+    #[zbus(name = "Cancel")]
+    fn cancel(&self, reason: String) {
+        let reason = CancellationReason::from_str(&reason).unwrap();
+        self.agent.cancel(reason);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use strum::EnumMessage;
 use thiserror::Error;
 
 pub mod access_point;
+pub mod agent;
 pub mod network;
 pub mod station;
 

--- a/src/error/agent.rs
+++ b/src/error/agent.rs
@@ -1,0 +1,18 @@
+use std::fmt::Display;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub struct Canceled();
+
+impl Display for Canceled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Canceled")
+    }
+}
+
+impl From<Canceled> for zbus::fdo::Error {
+    fn from(value: Canceled) -> Self {
+        zbus::fdo::Error::Failed(value.to_string())
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -114,7 +114,7 @@ impl Session {
             .collect()
     }
 
-    pub async fn register_agent(&self, agent: Agent) -> zbus::Result<AgentManager> {
+    pub async fn register_agent(&self, agent: impl Agent) -> zbus::Result<AgentManager> {
         let path =
             OwnedObjectPath::try_from(format!("/iwdrs/agent/{}", Uuid::new_v4().as_simple()))?;
         let agent_manager = AgentManager::new(self.connection.clone(), path);

--- a/src/station.rs
+++ b/src/station.rs
@@ -1,8 +1,13 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    cmp::Reverse,
+    collections::HashMap,
+    ops::{Bound, RangeBounds},
+    sync::Arc,
+};
 
 use zvariant::{OwnedObjectPath, Value};
 
-use zbus::{Connection, Proxy};
+use zbus::{Connection, Proxy, interface};
 
 use crate::{
     error::{
@@ -94,6 +99,39 @@ impl Station {
 
         Ok(networks)
     }
+
+    /// Register the agent object to receive signal strength level change notifications on the provided agent.
+    /// The "levels" parameters decides the thresholds in dBm that will generate a call to the
+    /// [`SignalLevelAgent::changed`] method whenever current RSSI crosses any of the values.  The number and distance between
+    /// requested threshold values is a compromise between resolution and the frequency of system wakeups and
+    /// context-switches that are going to be occurring to update the client's signal meter.  Only one agent
+    /// can be registered at any time.
+    pub async fn register_signal_level_agent(
+        &self,
+        mut levels: Vec<i16>,
+        agent: impl SignalLevelAgent,
+    ) -> zbus::Result<()> {
+        // Signal level boundaries should be sorted
+        levels.sort_by_key(|signal_level| Reverse(*signal_level));
+
+        let proxy = self.proxy().await?;
+
+        let interface = SignalLevelInterface {
+            agent,
+            connection: self.connection.clone(),
+            levels: levels.clone(),
+        };
+
+        self.connection
+            .object_server()
+            .at(self.dbus_path.clone(), interface)
+            .await?;
+
+        proxy
+            .call_method("RegisterSignalLevelAgent", &(&self.dbus_path, levels))
+            .await?;
+        Ok(())
+    }
 }
 
 impl StationDiagnostics {
@@ -132,5 +170,58 @@ impl StationDiagnostics {
             .collect::<HashMap<String, String>>();
 
         Ok(body)
+    }
+}
+
+pub trait SignalLevelAgent: Send + Sync + 'static {
+    /// This method gets called when the service daemon unregisters the agent. An agent can use it to do
+    /// cleanup tasks. There is no need to unregister the agent, because when this method gets called it has
+    /// already been unregistered.
+    fn release(&self) {}
+
+    fn changed(&self, station: &Station, signal_level: impl RangeBounds<i16>);
+}
+
+pub struct SignalLevelInterface<A> {
+    agent: A,
+    connection: Arc<Connection>,
+    levels: Vec<i16>,
+}
+
+#[interface(name = "net.connman.iwd.SignalLevelAgent")]
+impl<A: SignalLevelAgent> SignalLevelInterface<A> {
+    #[zbus(name = "Release")]
+    fn release(&self) {
+        self.agent.release();
+    }
+
+    /// This method gets called when the signal strength measurement for the device's connected network changes
+    /// enough to go from one level to another out of the N ranges defined by the array of (N-1) threshold values
+    /// passed to RegisterSignalLevelAgent().  It also gets registered.  The level parameter is in the range from 0
+    /// called immediately after the signal level agent is to N, 0 being the strongest signal or above the first
+    /// threshold value in the array, and N being the weakest and below the last threshold value.  For example if
+    /// RegisterSignalLevelAgent was called with the array [-40, -50, -60], the 'level' parameter of 0 would mean signal
+    /// is received at -40 or more dBm and 3 would mean below -60 dBm and might correspond to 1 out of 4 bars on a UI
+    /// signal meter.
+    #[zbus(name = "Changed")]
+    fn changed(&self, station_path: OwnedObjectPath, level_idx: u8) {
+        let station = Station {
+            connection: self.connection.clone(),
+            dbus_path: station_path,
+        };
+
+        let level_idx = usize::from(level_idx);
+        let max_strength = self
+            .levels
+            .get(level_idx - 1)
+            .map(|level| Bound::Excluded(*level))
+            .unwrap_or(Bound::Unbounded);
+        let min_strength = self
+            .levels
+            .get(level_idx)
+            .map(|level| Bound::Included(*level))
+            .unwrap_or(Bound::Unbounded);
+
+        self.agent.changed(&station, (min_strength, max_strength))
     }
 }


### PR DESCRIPTION
Uses a trait for registering agents as IMO it is much more idiomatic then manually creating a
```rust
pub type RequestPassPhraseFn = Box<
    dyn (Fn() -> Pin<Box<dyn Future<Output = Result<String, Box<dyn std::error::Error>>> + Send>>)
        + Send
        + Sync,
>;
```
For completeness, I have also added the other possible methods to the agent trait.

This PR also allows for registering `SignalLevelAgent`s by a similar mechanism. It is split out commit by commit, but let me know if you want it as two separate PR.