### PR TITLE
`tokio` or `async-io` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,18 @@ name = "iwdrs"
 version = "0.2.0"
 edition = "2024"
 license = "MIT"
-description = "Rust cratte for iwd"
+description = "Rust crate for iwd"
 readme = "Readme.md"
 homepage = "https://github.com/pythops/iwdrs"
 repository = "https://github.com/pythops/iwdrs"
 
+[features]
+default = ["async-io"]
+async-io = ["zbus/async-io"]
+tokio = ["zbus/tokio"]
+
 [dependencies]
-zbus = "5"
+zbus = { version = "5", default-features = false }
 zvariant = "5"
 uuid = { version = "1", features = ["v4"] }
 thiserror = "2.0.17"


### PR DESCRIPTION
Zbus allows you to choose between the `tokio` and `async-io` backends (See https://docs.rs/zbus/latest/zbus/#special-tokio-support). Lets not force users of this crate onto the (default) `async-io` backend.