### PR TITLE
Make `IWDError` implement `Display`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,9 +10,9 @@ pub type Result<T, E> = std::result::Result<T, IWDError<E>>;
 
 #[derive(Debug, Error)]
 pub enum IWDError<T: std::str::FromStr + std::error::Error> {
-    #[error("IWD threw an error")]
+    #[error("IWD Error: {0}")]
     OperationError(T),
-    #[error("Dbus error when executing IWD operation")]
+    #[error("Dbus error when executing IWD operation: {0}")]
     ZbusError(zbus::Error),
 }
 


### PR DESCRIPTION
Follow up to #4. The `IWDError` error type does not implement `Display`, which is sometimes necessary (e.g to coerce it into an `anyhow` error). Adding Descriptions to each variant makes `thiserror` implement display on the type.