### PR TITLE
Dont make a new `Proxy` for each operation.

### DIFF
--- a/examples/connect_network.rs
+++ b/examples/connect_network.rs
@@ -19,7 +19,7 @@ async fn main() {
     let agent = PasswdAgent(password);
     let _agent_manager = session.register_agent(agent).await.unwrap();
 
-    let station = session.stations().pop().unwrap();
+    let station = session.stations().await.unwrap().pop().unwrap();
     let mut networks = station.discovered_networks().await.unwrap();
 
     let network = match find_network(&ssid, &networks).await {

--- a/examples/monitor_signal_strength.rs
+++ b/examples/monitor_signal_strength.rs
@@ -14,7 +14,7 @@ async fn main() {
 
     let session = iwdrs::session::Session::new().await.unwrap();
 
-    let station = session.stations().pop().unwrap();
+    let station = session.stations().await.unwrap().pop().unwrap();
 
     station
         .register_signal_level_agent(levels, Agent {})

--- a/src/access_point.rs
+++ b/src/access_point.rs
@@ -1,65 +1,42 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 use zvariant::{OwnedObjectPath, Value};
 
 use zbus::{Connection, Proxy};
 
-use crate::error::{
-    Result as IWDResult,
-    access_point::{AccessPointStartError, AccessPointStopError, ScanError, StartProfileError},
+use crate::{
+    error::{
+        Result as IWDResult,
+        access_point::{AccessPointStartError, AccessPointStopError, ScanError, StartProfileError},
+    },
+    iwd_interface::iwd_interface_impl,
 };
 
-#[derive(Debug, Clone)]
-pub struct AccessPoint {
-    pub(crate) connection: Arc<Connection>,
-    pub(crate) dbus_path: OwnedObjectPath,
-}
+iwd_interface_impl!(AccessPoint, "net.connman.iwd.AccessPoint");
 
 impl AccessPoint {
-    pub(crate) fn new(connection: Arc<Connection>, dbus_path: OwnedObjectPath) -> Self {
-        Self {
-            connection,
-            dbus_path,
-        }
-    }
-
-    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>, zbus::Error> {
-        Proxy::new(
-            &self.connection,
-            "net.connman.iwd",
-            self.dbus_path.clone(),
-            "net.connman.iwd.AccessPoint",
-        )
-        .await
-    }
-
     // Methods
     pub async fn start(&self, ssid: &str, psk: &str) -> IWDResult<(), AccessPointStartError> {
-        let proxy = self.proxy().await?;
-        proxy.call_method("Start", &(ssid, psk)).await?;
+        self.proxy.call_method("Start", &(ssid, psk)).await?;
         Ok(())
     }
 
     pub async fn stop(&self) -> IWDResult<(), AccessPointStopError> {
-        let proxy = self.proxy().await?;
-        proxy.call_method("Stop", &()).await?;
+        self.proxy.call_method("Stop", &()).await?;
         Ok(())
     }
 
     pub async fn start_profile(&self, ssid: &str) -> IWDResult<(), StartProfileError> {
-        let proxy = self.proxy().await?;
-        proxy.call_method("StartProfile", &(ssid)).await?;
+        self.proxy.call_method("StartProfile", &(ssid)).await?;
         Ok(())
     }
 
     pub async fn scan(&self) -> IWDResult<(), ScanError> {
-        let proxy = self.proxy().await?;
-        proxy.call_method("Scan", &()).await?;
+        self.proxy.call_method("Scan", &()).await?;
         Ok(())
     }
 
     pub async fn networks(&self) -> zbus::Result<Vec<HashMap<String, String>>> {
-        let proxy = self.proxy().await?;
-        let networks = proxy.call_method("GetOrderedNetworks", &()).await?;
+        let networks = self.proxy.call_method("GetOrderedNetworks", &()).await?;
         let body = networks.body();
         let body: Vec<HashMap<String, Value>> = body.deserialize()?;
         let body = body
@@ -76,65 +53,40 @@ impl AccessPoint {
 
     // Proprieties
     pub async fn has_started(&self) -> zbus::Result<bool> {
-        let proxy = self.proxy().await?;
-        let has_started: bool = proxy.get_property("Started").await?;
+        let has_started: bool = self.proxy.get_property("Started").await?;
         Ok(has_started)
     }
 
     pub async fn frequency(&self) -> zbus::Result<Option<u32>> {
-        let proxy = self.proxy().await?;
-        Ok(proxy.get_property("Frequency").await.ok())
+        Ok(self.proxy.get_property("Frequency").await.ok())
     }
 
     pub async fn is_scanning(&self) -> zbus::Result<bool> {
-        let proxy = self.proxy().await?;
-        let is_scanning: bool = proxy.get_property("Scanning").await?;
+        let is_scanning: bool = self.proxy.get_property("Scanning").await?;
         Ok(is_scanning)
     }
 
     pub async fn name(&self) -> zbus::Result<Option<String>> {
-        let proxy = self.proxy().await?;
-        Ok(proxy.get_property("Name").await.ok())
+        Ok(self.proxy.get_property("Name").await.ok())
     }
 
     pub async fn pairwise_ciphers(&self) -> zbus::Result<Option<Vec<String>>> {
-        let proxy = self.proxy().await?;
-        Ok(proxy.get_property("PairwiseCiphers").await.ok())
+        Ok(self.proxy.get_property("PairwiseCiphers").await.ok())
     }
 
     pub async fn group_cipher(&self) -> zbus::Result<Option<String>> {
-        let proxy = self.proxy().await?;
-        Ok(proxy.get_property("GroupCipher").await.ok())
+        Ok(self.proxy.get_property("GroupCipher").await.ok())
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct AccessPointDiagnostics {
-    pub(crate) connection: Arc<Connection>,
-    pub(crate) dbus_path: OwnedObjectPath,
-}
+iwd_interface_impl!(
+    AccessPointDiagnostics,
+    "net.connman.iwd.AccessPointDiagnostic"
+);
 
 impl AccessPointDiagnostics {
-    pub(crate) fn new(connection: Arc<Connection>, dbus_path: OwnedObjectPath) -> Self {
-        Self {
-            connection,
-            dbus_path,
-        }
-    }
-
-    pub(crate) async fn proxy<'a>(&self) -> zbus::Result<zbus::Proxy<'a>> {
-        Proxy::new(
-            &self.connection,
-            "net.connman.iwd",
-            self.dbus_path.clone(),
-            "net.connman.iwd.AccessPointDiagnostic",
-        )
-        .await
-    }
-
     pub async fn get(&self) -> zbus::Result<Vec<HashMap<String, String>>> {
-        let proxy = self.proxy().await?;
-        let diagnostic = proxy.call_method("GetDiagnostics", &()).await?;
+        let diagnostic = self.proxy.call_method("GetDiagnostics", &()).await?;
 
         let body = diagnostic.body();
         let body: Vec<HashMap<String, Value>> = body.deserialize()?;

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,65 +1,34 @@
-use std::sync::Arc;
-
 use zbus::{Connection, Proxy, Result};
 use zvariant::OwnedObjectPath;
 
-#[derive(Clone, Debug)]
-pub struct Adapter {
-    pub(crate) connection: Arc<Connection>,
-    pub(crate) dbus_path: OwnedObjectPath,
-}
+use crate::iwd_interface::iwd_interface_impl;
+
+iwd_interface_impl!(Adapter, "net.connman.iwd.Adapter");
 
 impl Adapter {
-    pub(crate) fn new(connection: Arc<Connection>, dbus_path: OwnedObjectPath) -> Self {
-        Self {
-            connection,
-            dbus_path,
-        }
-    }
-
-    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>> {
-        Proxy::new(
-            &self.connection,
-            "net.connman.iwd",
-            self.dbus_path.clone(),
-            "net.connman.iwd.Adapter",
-        )
-        .await
-    }
-
     pub async fn name(&self) -> Result<String> {
-        let proxy = self.proxy().await?;
-        let name: String = proxy.get_property("Name").await?;
-        Ok(name)
+        self.proxy.get_property("Name").await
     }
 
     pub async fn model(&self) -> Result<String> {
-        let proxy = self.proxy().await?;
-        let model: String = proxy.get_property("Model").await?;
-        Ok(model)
+        self.proxy.get_property("Model").await
     }
 
     pub async fn vendor(&self) -> Result<String> {
-        let proxy = self.proxy().await?;
-        let vendor: String = proxy.get_property("Vendor").await?;
-        Ok(vendor)
+        self.proxy.get_property("Vendor").await
     }
 
     pub async fn supported_modes(&self) -> Result<Vec<String>> {
-        let proxy = self.proxy().await?;
-        let modes: Vec<String> = proxy.get_property("SupportedModes").await?;
-        Ok(modes)
+        self.proxy.get_property("SupportedModes").await
     }
 
     pub async fn is_powered(&self) -> Result<bool> {
-        let proxy = self.proxy().await?;
-        let is_powered: bool = proxy.get_property("Powered").await?;
+        let is_powered: bool = self.proxy.get_property("Powered").await?;
         Ok(is_powered)
     }
 
     pub async fn set_power(&self, mode: bool) -> Result<()> {
-        let proxy = self.proxy().await?;
-        proxy.set_property("Powered", mode).await?;
+        self.proxy.set_property("Powered", mode).await?;
         Ok(())
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,57 +1,31 @@
-use std::sync::Arc;
-
+use zbus::{Connection, Proxy, Result};
 use zvariant::OwnedObjectPath;
 
-use zbus::{Connection, Proxy, Result};
+use crate::{
+    adapter::Adapter,
+    iwd_interface::{IwdInterface, iwd_interface_impl},
+    modes::Mode,
+};
 
-use crate::{adapter::Adapter, modes::Mode};
-
-#[derive(Debug, Clone)]
-pub struct Device {
-    pub(crate) connection: Arc<Connection>,
-    pub(crate) dbus_path: OwnedObjectPath,
-}
+iwd_interface_impl!(Device, "net.connman.iwd.Device");
 
 impl Device {
-    pub(crate) fn new(connection: Arc<Connection>, dbus_path: OwnedObjectPath) -> Self {
-        Self {
-            connection,
-            dbus_path,
-        }
-    }
-
-    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>> {
-        Proxy::new(
-            &self.connection,
-            "net.connman.iwd",
-            self.dbus_path.clone(),
-            "net.connman.iwd.Device",
-        )
-        .await
-    }
-
     pub async fn name(&self) -> Result<String> {
-        let proxy = self.proxy().await?;
-        let name: String = proxy.get_property("Name").await?;
-        Ok(name)
+        self.proxy.get_property("Name").await
     }
 
     pub async fn address(&self) -> Result<String> {
-        let proxy = self.proxy().await?;
-        let address: String = proxy.get_property("Address").await?;
-        Ok(address)
+        self.proxy.get_property("Address").await
     }
 
     pub async fn adapter(&self) -> Result<Adapter> {
-        let proxy = self.proxy().await?;
-        let adapter_path: OwnedObjectPath = proxy.get_property("Adapter").await?;
-        let adapter = Adapter::new(self.connection.clone(), adapter_path);
+        let adapter_path: OwnedObjectPath = self.proxy.get_property("Adapter").await?;
+        let adapter = Adapter::new(self.proxy.connection().clone(), adapter_path).await?;
         Ok(adapter)
     }
 
     pub async fn get_mode(&self) -> Result<Mode> {
-        let proxy = self.proxy().await?;
-        let mode: String = proxy.get_property("Mode").await?;
+        let mode: String = self.proxy.get_property("Mode").await?;
 
         match mode.as_str() {
             "station" => Ok(Mode::Station),
@@ -61,20 +35,17 @@ impl Device {
     }
 
     pub async fn is_powered(&self) -> Result<bool> {
-        let proxy = self.proxy().await?;
-        let is_powered: bool = proxy.get_property("Powered").await?;
+        let is_powered: bool = self.proxy.get_property("Powered").await?;
         Ok(is_powered)
     }
 
     pub async fn set_mode(&self, mode: Mode) -> Result<()> {
-        let proxy = self.proxy().await?;
-        proxy.set_property("Mode", mode.to_string()).await?;
+        self.proxy.set_property("Mode", mode.to_string()).await?;
         Ok(())
     }
 
     pub async fn set_power(&self, mode: bool) -> Result<()> {
-        let proxy = self.proxy().await?;
-        proxy.set_property("Powered", mode).await?;
+        self.proxy.set_property("Powered", mode).await?;
         Ok(())
     }
 }

--- a/src/iwd_interface.rs
+++ b/src/iwd_interface.rs
@@ -1,0 +1,38 @@
+use zbus::{Connection, Proxy};
+use zvariant::OwnedObjectPath;
+
+const DESTINATION: &str = "net.connman.iwd";
+
+pub trait IwdInterface: Sized {
+    const INTERFACE: &str;
+
+    async fn new(connection: Connection, dbus_path: OwnedObjectPath) -> zbus::Result<Self>;
+
+    async fn proxy(
+        connection: Connection,
+        dbus_path: OwnedObjectPath,
+    ) -> zbus::Result<Proxy<'static>> {
+        Proxy::new_owned(connection, DESTINATION, dbus_path, Self::INTERFACE).await
+    }
+}
+
+macro_rules! iwd_interface_impl {
+    ($interface_ty:ident, $interface_name:expr) => {
+        #[derive(Clone, Debug)]
+        pub struct $interface_ty {
+            proxy: Proxy<'static>,
+        }
+
+        impl crate::iwd_interface::IwdInterface for $interface_ty {
+            const INTERFACE: &str = $interface_name;
+
+            async fn new(connection: Connection, dbus_path: OwnedObjectPath) -> zbus::Result<Self> {
+                Ok(Self {
+                    proxy: Self::proxy(connection, dbus_path).await?,
+                })
+            }
+        }
+    };
+}
+
+pub(crate) use iwd_interface_impl;

--- a/src/known_network.rs
+++ b/src/known_network.rs
@@ -1,72 +1,40 @@
-use std::sync::Arc;
-
 use zbus::{Connection, Proxy, Result};
 use zvariant::OwnedObjectPath;
 
-use crate::network::NetworkType;
+use crate::{iwd_interface::iwd_interface_impl, network::NetworkType};
 
-#[derive(Clone, Debug)]
-pub struct KnownNetwork {
-    pub(crate) connection: Arc<Connection>,
-    pub(crate) dbus_path: OwnedObjectPath,
-}
+iwd_interface_impl!(KnownNetwork, "net.connman.iwd.AccessPoint");
 
 impl KnownNetwork {
-    pub fn new(connection: Arc<Connection>, dbus_path: OwnedObjectPath) -> Self {
-        Self {
-            connection,
-            dbus_path,
-        }
-    }
-
-    async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>> {
-        Proxy::new(
-            &self.connection,
-            "net.connman.iwd",
-            self.dbus_path.clone(),
-            "net.connman.iwd.KnownNetwork",
-        )
-        .await
-    }
-
     pub async fn forget(&self) -> Result<()> {
-        let proxy = self.proxy().await?;
-        proxy.call_method("Forget", &()).await?;
+        self.proxy.call_method("Forget", &()).await?;
         Ok(())
     }
 
     pub async fn name(&self) -> Result<String> {
-        let proxy = self.proxy().await?;
-        let name: String = proxy.get_property("Name").await?;
-        Ok(name)
+        self.proxy.get_property("Name").await
     }
 
     pub async fn network_type(&self) -> Result<NetworkType> {
-        let proxy = self.proxy().await?;
-        proxy.get_property("Type").await
+        self.proxy.get_property("Type").await
     }
 
     pub async fn hidden(&self) -> Result<bool> {
-        let proxy = self.proxy().await?;
-        let hidden: bool = proxy.get_property("Hidden").await?;
+        let hidden: bool = self.proxy.get_property("Hidden").await?;
         Ok(hidden)
     }
 
     pub async fn last_connected_time(&self) -> Result<String> {
-        let proxy = self.proxy().await?;
-        let last_time: String = proxy.get_property("LastConnectedTime").await?;
-        Ok(last_time)
+        self.proxy.get_property("LastConnectedTime").await
     }
 
     pub async fn set_autoconnect(&self, auto_connect: bool) -> Result<()> {
-        let proxy = self.proxy().await?;
-        proxy.set_property("AutoConnect", auto_connect).await?;
+        self.proxy.set_property("AutoConnect", auto_connect).await?;
         Ok(())
     }
 
     pub async fn get_autoconnect(&self) -> Result<bool> {
-        let proxy = self.proxy().await?;
-        let auto_connect: bool = proxy.get_property("AutoConnect").await?;
+        let auto_connect: bool = self.proxy.get_property("AutoConnect").await?;
         Ok(auto_connect)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod modes;
 
 pub mod error;
 
+mod iwd_interface;
+
 async fn property_stream<T: TryFrom<OwnedValue, Error = zvariant::Error> + Unpin>(
     proxy: Proxy<'static>,
     property_name: &'static str,

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use futures_lite::{Stream, StreamExt};
 use strum::EnumString;
@@ -8,45 +8,23 @@ use zvariant::{OwnedObjectPath, OwnedValue};
 use crate::{
     device::Device,
     error::{IWDError, network::ConnectError},
+    iwd_interface::{IwdInterface, iwd_interface_impl},
     known_network::KnownNetwork,
 };
 
-#[derive(Clone, Debug)]
-pub struct Network {
-    pub(crate) connection: Arc<Connection>,
-    pub(crate) dbus_path: OwnedObjectPath,
-}
+iwd_interface_impl!(Network, "net.connman.iwd.Network");
 
 impl Network {
-    pub(crate) fn new(connection: Arc<Connection>, dbus_path: OwnedObjectPath) -> Self {
-        Self {
-            connection,
-            dbus_path,
-        }
-    }
-
-    pub(crate) async fn proxy<'a>(&self) -> Result<zbus::Proxy<'a>, zbus::Error> {
-        Proxy::new(
-            &self.connection,
-            "net.connman.iwd",
-            self.dbus_path.clone(),
-            "net.connman.iwd.Network",
-        )
-        .await
-    }
-
     // Methods
     pub async fn connect(&self) -> Result<(), IWDError<ConnectError>> {
-        let proxy = self.proxy().await?;
-        proxy.call_method("Connect", &()).await?;
+        self.proxy.call_method("Connect", &()).await?;
         Ok(())
     }
 
     // Properties
 
     pub async fn name(&self) -> ZbusResult<String> {
-        let proxy = self.proxy().await?;
-        let name: String = proxy.get_property("Name").await?;
+        let name: String = self.proxy.get_property("Name").await?;
         Ok(name)
     }
 
@@ -61,28 +39,27 @@ impl Network {
     pub async fn connected_stream(
         &self,
     ) -> zbus::Result<impl Stream<Item = zbus::Result<bool>> + Unpin> {
-        let proxy = self.proxy().await?;
-        crate::property_stream(proxy, "Connected").await
+        crate::property_stream(self.proxy.clone(), "Connected").await
     }
 
     pub async fn device(&self) -> ZbusResult<Device> {
-        let proxy = self.proxy().await?;
-        let device_path: OwnedObjectPath = proxy.get_property("Device").await?;
+        let device_path: OwnedObjectPath = self.proxy.get_property("Device").await?;
 
-        let device = Device::new(self.connection.clone(), device_path);
-        Ok(device)
+        Device::new(self.proxy.connection().clone(), device_path).await
     }
 
     pub async fn network_type(&self) -> ZbusResult<NetworkType> {
-        let proxy = self.proxy().await?;
-        proxy.get_property("Type").await
+        self.proxy.get_property("Type").await
     }
 
     pub async fn known_network(&self) -> ZbusResult<Option<KnownNetwork>> {
-        let proxy = self.proxy().await?;
-        if let Ok(known_network_path) = proxy.get_property::<OwnedObjectPath>("KnownNetwork").await
+        if let Ok(known_network_path) = self
+            .proxy
+            .get_property::<OwnedObjectPath>("KnownNetwork")
+            .await
         {
-            let network = KnownNetwork::new(self.connection.clone(), known_network_path);
+            let network =
+                KnownNetwork::new(self.proxy.connection().clone(), known_network_path).await?;
             return Ok(Some(network));
         }
         Ok(None)


### PR DESCRIPTION
Before this PR `iwrds`  currently makes a new `zbus::Proxy` for each operation. This causes some overhead (zbus has to make a new property cache for each operation) and also unnecessarily complicates out code. I think it was don't this way because by default `Proxy` has a bounded lifetime on the connection, but using `Proxy::new_owned` we can make a `Proxy<'static>` to get around the lifetime issues.

`iwdrs` way also unnecessarily creating `Arc<zbus::Connection>` when `zbus::Connection` implements `Clone` (it is just an `Arc` inside).

While writing this code I was able to generalize object creation in the `IwdInterface` trait, which significantly simplifies the logic in session.