### PR TITLE
Fix Stream Initial Value Inconsistencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use futures_lite::{Stream, StreamExt};
+use futures_lite::{Stream, StreamExt, stream};
 use zbus::Proxy;
 use zvariant::OwnedValue;
 
@@ -26,12 +26,19 @@ mod iwd_interface;
 
 async fn property_stream<T: TryFrom<OwnedValue, Error = zvariant::Error> + Unpin>(
     proxy: Proxy<'static>,
+    initial_value: zbus::Result<T>,
     property_name: &'static str,
 ) -> zbus::Result<impl Stream<Item = zbus::Result<T>> + Unpin> {
+    // `receive_property_changed` does not yield the initial value if another stream on the same property has already
+    // been created and yielded a value. Therefore we manually add an initial value to the beginning of the stream
+    // as most consumers will expect it to be there. Note that the first stream created for each property (per proxy)
+    // will initially yield two elements, but I think that is a worthwhile tradeoff.
     Ok(Box::pin(
-        proxy
-            .receive_property_changed(property_name)
-            .await
-            .then(|property_changed| async move { property_changed.get().await }),
+        stream::iter([initial_value]).chain(
+            proxy
+                .receive_property_changed(property_name)
+                .await
+                .then(|property_changed| async move { property_changed.get().await }),
+        ),
     ))
 }


### PR DESCRIPTION
See the comment in `lib.rs`

That was causing `Network::connected` and `Station::state` to never return if a stream listener had already been created. I decided to simplify them to just receive the property directly. This problem started manifesting in #13 because each (non-cloned) proxy has its own property cache and we were never re-using a proxy before.