### PR TITLE
ScanError::Busy may be serialized as `net.connman.iwd.InProgress`

### DIFF
--- a/src/error/station.rs
+++ b/src/error/station.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 pub enum ScanError {
     #[strum(
         serialize = "net.connman.iwd.Busy",
+        serialize = "net.connman.iwd.InProgress",
         message = "InProgress",
         detailed_message = "Operation already in progress"
     )]


### PR DESCRIPTION
Found error code being thrown on debian 12, despite what
https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/doc/station-api.txt says.