### PR TITLE
Fix stale D-Bus object cache in Session

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 
 pub mod access_point;
 pub mod agent;
+pub mod monitor;
 pub mod network;
 pub mod station;
 
@@ -25,11 +26,9 @@ impl<T: std::str::FromStr<Err = strum::ParseError> + std::error::Error + EnumMes
         };
         match T::from_str(error_name.as_str()) {
             Ok(error) => {
-                debug_assert!(
-                    _error_description
-                        .as_ref()
-                        .is_some_and(|err| err.as_str() == error.get_detailed_message().unwrap())
-                );
+                debug_assert!(_error_description
+                    .as_ref()
+                    .is_some_and(|err| err.as_str() == error.get_detailed_message().unwrap()));
 
                 Self::OperationError(error)
             }

--- a/src/error/monitor.rs
+++ b/src/error/monitor.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+/// Error returned when the [`Session::with_monitor`] monitor future terminates.
+///
+/// [`Session::with_monitor`]: crate::session::Session::with_monitor
+#[derive(Debug, Error)]
+pub enum MonitorError {
+    /// The `InterfacesAdded` signal stream ended unexpectedly.
+    #[error("InterfacesAdded signal stream ended")]
+    InterfacesAddedStreamEnded,
+
+    /// The `InterfacesRemoved` signal stream ended unexpectedly.
+    #[error("InterfacesRemoved signal stream ended")]
+    InterfacesRemovedStreamEnded,
+
+    /// A D-Bus error occurred while processing a signal.
+    #[error("D-Bus error: {0}")]
+    ZbusError(#[from] zbus::Error),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hidden_network;
 mod iwd_interface;
 pub mod known_network;
 pub mod modes;
+pub(crate) mod monitor;
 pub mod network;
 pub mod session;
 pub mod station;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,0 +1,100 @@
+use crate::error::monitor::MonitorError;
+use futures_lite::StreamExt;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+use zbus::{
+    fdo::{InterfacesAddedStream, InterfacesRemovedStream, ManagedObjects, ObjectManagerProxy},
+    names::OwnedInterfaceName,
+};
+use zvariant::{OwnedObjectPath, OwnedValue};
+
+/// Sets up the D-Bus signal subscriptions and initial object snapshot for
+/// monitoring iwd's managed objects.
+///
+/// Returns the shared object cache and an async future that keeps it up to
+/// date by processing `InterfacesAdded` and `InterfacesRemoved` signals.
+pub(crate) async fn setup_monitored_objects(
+    object_manager: ObjectManagerProxy<'static>,
+) -> zbus::Result<(
+    Arc<RwLock<ManagedObjects>>,
+    impl std::future::Future<Output = Result<(), MonitorError>> + Send,
+)> {
+    // Subscribe to signals *before* querying GetManagedObjects to avoid
+    // a race where an object is added between the query and the subscription.
+    let mut added_stream = object_manager.receive_interfaces_added().await?;
+    let mut removed_stream = object_manager.receive_interfaces_removed().await?;
+
+    let objects = object_manager.get_managed_objects().await?;
+    let objects = Arc::new(RwLock::new(objects));
+    let monitor_objects = Arc::clone(&objects);
+
+    let monitor = async move {
+        // Keep the object_manager alive for the lifetime of the monitor
+        // so the signal streams remain valid.
+        let _object_manager = object_manager;
+
+        loop {
+            futures_lite::future::race(
+                handle_interfaces_added(&mut added_stream, &monitor_objects),
+                handle_interfaces_removed(&mut removed_stream, &monitor_objects),
+            )
+            .await?;
+        }
+    };
+
+    Ok((objects, monitor))
+}
+
+async fn handle_interfaces_added(
+    stream: &mut InterfacesAddedStream,
+    objects: &Arc<RwLock<ManagedObjects>>,
+) -> Result<(), MonitorError> {
+    let signal = stream
+        .next()
+        .await
+        .ok_or(MonitorError::InterfacesAddedStreamEnded)?;
+    let args = signal.args()?;
+    let path = args.object_path.to_owned().into();
+    let interfaces: HashMap<OwnedInterfaceName, HashMap<String, OwnedValue>> = args
+        .interfaces_and_properties
+        .iter()
+        .map(|(iface, props)| {
+            let owned_props: HashMap<String, OwnedValue> = props
+                .iter()
+                .filter_map(|(k, v)| Some((k.to_string(), v.try_to_owned().ok()?)))
+                .collect();
+            (iface.to_owned().into(), owned_props)
+        })
+        .collect();
+    objects
+        .write()
+        .expect("monitor objects lock poisoned")
+        .entry(path)
+        .or_default()
+        .extend(interfaces);
+    Ok(())
+}
+
+async fn handle_interfaces_removed(
+    stream: &mut InterfacesRemovedStream,
+    objects: &Arc<RwLock<ManagedObjects>>,
+) -> Result<(), MonitorError> {
+    let signal = stream
+        .next()
+        .await
+        .ok_or(MonitorError::InterfacesRemovedStreamEnded)?;
+    let args = signal.args()?;
+    let path: OwnedObjectPath = args.object_path.to_owned().into();
+    let mut objects = objects.write().expect("monitor objects lock poisoned");
+    if let Some(ifaces) = objects.get_mut(&path) {
+        for iface_name in args.interfaces.iter() {
+            ifaces.remove(iface_name.as_str());
+        }
+        if ifaces.is_empty() {
+            objects.remove(&path);
+        }
+    }
+    Ok(())
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,59 +4,110 @@ use crate::{
     agent::{Agent, AgentManager},
     daemon::Daemon,
     device::Device,
+    error::monitor::MonitorError,
     iwd_interface::{self, IwdInterface},
     known_network::KnownNetwork,
+    monitor,
     station::{Station, StationDiagnostics},
 };
-use std::collections::HashMap;
+use std::{
+    future::Future,
+    sync::{Arc, RwLock},
+};
 use uuid::Uuid;
-use zbus::{Connection, Proxy};
-use zvariant::{OwnedObjectPath, OwnedValue};
+use zbus::{
+    Connection,
+    fdo::{ManagedObjects, ObjectManagerProxy},
+};
+use zvariant::OwnedObjectPath;
 
 #[derive(Debug)]
 pub struct Session {
     connection: Connection,
-    pub(crate) objects: HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>>,
+    objects: Arc<RwLock<ManagedObjects>>,
 }
 
 impl Session {
+    /// Creates a new Session by querying iwd's current D-Bus objects.
+    ///
+    /// The object cache is populated once at creation time and is not
+    /// automatically updated. For a session that stays up to date, use
+    /// [`Session::with_monitor`].
     pub async fn new() -> zbus::Result<Self> {
         let connection = Connection::system().await?;
 
-        let proxy = Proxy::new(
-            &connection,
-            "net.connman.iwd",
-            "/",
-            "org.freedesktop.DBus.ObjectManager",
-        )
-        .await?;
+        let object_manager = ObjectManagerProxy::new(&connection, "net.connman.iwd", "/").await?;
 
-        let objects: HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>> =
-            proxy.call("GetManagedObjects", &()).await?;
+        let objects = object_manager.get_managed_objects().await?;
 
         Ok(Self {
             connection,
-            objects,
+            objects: Arc::new(RwLock::new(objects)),
         })
     }
 
-    fn object_type(
-        &self,
-        interface_type: &'static str,
-    ) -> impl IntoIterator<Item = OwnedObjectPath> {
-        self.objects.iter().flat_map(move |(path, interfaces)| {
-            let path = path.clone();
-            interfaces
-                .iter()
-                .filter(move |(interface, _)| interface.as_str() == interface_type)
-                .map(move |_| path.clone())
-        })
+    /// Creates a new Session and returns an async future that keeps the
+    /// internal object cache up to date by monitoring D-Bus
+    /// [`InterfacesAdded`] and [`InterfacesRemoved`] signals.
+    ///
+    /// The caller must spawn the returned future in their async runtime.
+    /// The future runs indefinitely until a D-Bus error occurs or the
+    /// signal streams end.
+    ///
+    /// If the monitor future is not spawned, the session behaves
+    /// identically to one created with [`Session::new`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use iwdrs::session::Session;
+    ///
+    /// let (session, monitor) = Session::with_monitor().await?;
+    ///
+    /// // Spawn with tokio:
+    /// // tokio::spawn(monitor);
+    ///
+    /// // Or with async-std / smol:
+    /// // async_std::task::spawn(monitor);
+    ///
+    /// // The session's object cache now stays up to date.
+    /// let networks = session.known_networks().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`InterfacesAdded`]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager
+    /// [`InterfacesRemoved`]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager
+    pub async fn with_monitor()
+    -> zbus::Result<(Self, impl Future<Output = Result<(), MonitorError>> + Send)> {
+        let connection = Connection::system().await?;
+
+        let object_manager = ObjectManagerProxy::new(&connection, "net.connman.iwd", "/").await?;
+
+        let (objects, monitor_future) = monitor::setup_monitored_objects(object_manager).await?;
+
+        let session = Self {
+            connection,
+            objects,
+        };
+
+        Ok((session, monitor_future))
+    }
+
+    fn object_type(&self, interface_type: &'static str) -> Vec<OwnedObjectPath> {
+        let objects = self.objects.read().expect("objects lock poisoned");
+        objects
+            .iter()
+            .filter(|(_, interfaces)| interfaces.contains_key(interface_type))
+            .map(|(path, _)| path.clone())
+            .collect()
     }
 
     async fn collect_interface<Output: iwd_interface::IwdInterface>(
         &self,
     ) -> zbus::Result<Vec<Output>> {
-        let paths: Vec<_> = self.object_type(Output::INTERFACE).into_iter().collect();
+        let paths = self.object_type(Output::INTERFACE);
         let mut results = Vec::with_capacity(paths.len());
         for path in paths {
             results.push(Output::new(self.connection.clone(), path).await?);


### PR DESCRIPTION
## Problem

`Session::new()` calls `GetManagedObjects` once and caches the result. Objects created after session initialization (e.g. `KnownNetwork` entries for newly connected networks) are invisible to methods like `known_networks()`, causing operations like `forget()` to fail.

### Reproduction

```rs
#[tokio::main]
async fn main() {
    let session = iwdrs::session::Session::new().await.unwrap();

    loop {
        eprint!("Press enter: ");
        let mut line = String::new();
        std::io::stdin().read_line(&mut line).unwrap();

        let known_networks = session.known_networks().await.unwrap();
        for network in known_networks {
            let network = network.name().await.unwrap();
            println!("Found: {network}");
        }
        println!();
    }
}
```

1. Make sure network A is not known (eg. by forgetting it using `iwctl`)
2. Run the above program
3. Press enter to show known networks, A is not in the list (correct behavior)
4. In a separate terminal, connect to network A using `iwctl`
5. Press enter to refresh, A is still not shown (bug)
6. Restart the above program
7. Press enter to refresh, A is now in the list (correct behavior)
8. In a separate terminal, forget network A using `iwctl`
9. Press enter to refresh, the program crashes (bug)
  ```
  thread 'main' (185420) panicked at src/main.rs:13:48:
  called `Result::unwrap()` on an `Err` value: MethodError(OwnedErrorName("org.freedesktop.DBus.Error.NotFound"), Some("No matching method found"), Msg { type: Error, serial: 143554, sender: UniqueName(":1.9"), reply-serial: 18, body: Str, fds: [] })
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```

## Solution

`Session::with_monitor()`, which returns the session and an async future that keeps the object cache up to date by listening to the `ObjectManager`'s `InterfacesAdded` and `InterfacesRemoved` D-Bus signals.

For backwards compatibility, the existing `new()` constructor is unchanged. The monitor pattern is used so interface updates can be driven by the consumer's preferred async runtime.

Would appreciate a new release if this PR is merged. Let me know if you have any concerns.