### PR TITLE
Fix SignalLevelAgent connection leak and object cache corruption

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -140,7 +140,12 @@ impl ObjectCache {
     async fn update_objects_cache(&mut self) -> zbus::Result<()> {
         while let Some(removal) = self.interfaces_removed.next().or(future::ready(None)).await {
             let args = removal.args()?;
-            self.objects.remove(args.object_path());
+            if let Some(interfaces) = self.objects.get_mut(args.object_path()) {
+                interfaces.retain(|name, _| !args.interfaces().contains(name));
+                if interfaces.is_empty() {
+                    self.objects.remove(args.object_path());
+                }
+            }
         }
 
         while let Some(added) = self.interfaces_added.next().or(future::ready(None)).await {
@@ -167,7 +172,10 @@ impl ObjectCache {
                     (iface, props)
                 })
                 .collect();
-            self.objects.insert(object_path, interfaces_and_properties);
+            self.objects
+                .entry(object_path)
+                .or_default()
+                .extend(interfaces_and_properties);
         }
 
         Ok(())

--- a/src/session.rs
+++ b/src/session.rs
@@ -90,6 +90,10 @@ impl Session {
         self.collect_interface().await
     }
 
+    pub async fn station_at(&self, path: OwnedObjectPath) -> zbus::Result<Station> {
+        Station::new(self.connection.clone(), path).await
+    }
+
     pub async fn stations_diagnostics(&self) -> zbus::Result<Vec<StationDiagnostics>> {
         self.collect_interface().await
     }

--- a/src/station.rs
+++ b/src/station.rs
@@ -2,7 +2,7 @@ use std::{cmp::Reverse, collections::HashMap, str::FromStr};
 
 use futures_lite::{Stream, StreamExt, stream};
 use strum::EnumString;
-use zvariant::{OwnedObjectPath, OwnedValue, Value};
+use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 
 use zbus::{Connection, Proxy};
 
@@ -155,6 +155,10 @@ impl Station {
                 Err(register_error)
             }
         }
+    }
+
+    pub fn path(&self) -> &ObjectPath<'_> {
+        self.proxy.path()
     }
 }
 

--- a/src/station.rs
+++ b/src/station.rs
@@ -123,26 +123,38 @@ impl Station {
     /// The number and distance between requested threshold values is a compromise between resolution and the frequency of system
     /// wakeups and context-switches that are going to be occurring to update the client's signal meter.  Only one agent
     /// can be registered at any time.
-    pub async fn register_signal_level_agent(
+    pub async fn register_signal_level_agent<A: signal_level_agent::SignalLevelAgent>(
         &self,
         mut levels: Vec<i16>,
-        agent: impl signal_level_agent::SignalLevelAgent,
+        agent: A,
     ) -> zbus::Result<SignalLevelAgentManager> {
         // Signal level boundaries should be sorted
         levels.sort_by_key(|signal_level| Reverse(*signal_level));
 
         let interface = signal_level_agent::SignalLevelInterface {
             agent,
-            connection: self.proxy.connection().clone(),
             levels: levels.clone(),
         };
 
         let manager = SignalLevelAgentManager::register_agent(self.clone(), interface).await?;
 
-        self.proxy
+        match self
+            .proxy
             .call_method("RegisterSignalLevelAgent", &(&manager.dbus_path, levels))
-            .await?;
-        Ok(manager)
+            .await
+        {
+            Ok(_) => Ok(manager),
+            Err(register_error) => {
+                // iwd rejected the registration, remove the served object again so it does not accumulate on the object server.
+                let _ = self
+                    .proxy
+                    .connection()
+                    .object_server()
+                    .remove::<signal_level_agent::SignalLevelInterface<A>, _>(&manager.dbus_path)
+                    .await;
+                Err(register_error)
+            }
+        }
     }
 }
 

--- a/src/station/signal_level_agent.rs
+++ b/src/station/signal_level_agent.rs
@@ -17,7 +17,6 @@ pub trait SignalLevelAgent: Send + Sync + 'static {
 
 pub struct SignalLevelInterface<A> {
     pub(super) agent: A,
-    pub(super) connection: Connection,
     pub(super) levels: Vec<i16>,
 }
 
@@ -37,8 +36,13 @@ impl<A: SignalLevelAgent> SignalLevelInterface<A> {
     /// is received at -40 or more dBm and 3 would mean below -60 dBm and might correspond to 1 out of 4 bars on a UI
     /// signal meter.
     #[zbus(name = "Changed")]
-    async fn changed(&self, station_path: OwnedObjectPath, level_idx: u8) -> zbus::fdo::Result<()> {
-        let station = Station::new(self.connection.clone(), station_path).await?;
+    async fn changed(
+        &self,
+        station_path: OwnedObjectPath,
+        level_idx: u8,
+        #[zbus(connection)] connection: &Connection,
+    ) -> zbus::fdo::Result<()> {
+        let station = Station::new(connection.clone(), station_path).await?;
 
         let level_idx = usize::from(level_idx);
 


### PR DESCRIPTION
Two bug fixes and a small API addition, found while debugging a fleet of embedded devices showing stale wifi state and eventually lost system-bus access entirely.

### 1. `SignalLevelInterface` held a `Connection` reference cycle

The interface object served for `RegisterSignalLevelAgent` stored a `Connection` clone while itself being stored in that connection's `ObjectServer`. The resulting reference cycle means dropping the `Session` never actually closes the connection, so:

- every `register_signal_level_agent` call leaks one D-Bus connection for the life of the process, and
- iwd keeps the agent registered (it cleans up on connection close), so any later registration fails with `net.connman.iwd.AlreadyExists`.

Each retry fails with `AlreadyExists`, leaks another connection, and with dbus-daemon's default `max_connections_per_user=256` the process locks its whole user out of the system bus in a few minutes. Fixed by injecting the connection into `Changed()` via `#[zbus(connection)]` instead of storing it, and by removing the served object again when `RegisterSignalLevelAgent` is rejected.

### 2. Object cache treated ObjectManager signals as whole-object updates

`InterfacesAdded` / `InterfacesRemoved` describe per-interface deltas ([D-Bus spec](https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager)), but `update_objects_cache` replaced / removed the whole object entry. Now added interfaces merge into the existing map and only the named interfaces are removed.

### 3. `Session` API additions

Lets a caller rebuild a `Station` proxy at a known object path. A fresh proxy has no primed property cache, so callers that poll as a fallback for missed `PropertiesChanged` signals get a D-Bus read rather than potentially stale cached state.