### PR TITLE
Remove object manager cache (Revert #24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -186,7 +186,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -240,9 +240,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -262,14 +262,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -323,7 +323,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -498,7 +498,6 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "iwdrs"
 version = "0.2.7"
 dependencies = [
- "async-lock",
  "clap",
  "futures-lite",
  "strum",
@@ -637,7 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -725,7 +724,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -749,7 +748,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -802,7 +801,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -810,6 +809,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -846,7 +856,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -868,13 +878,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -926,7 +936,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1035,7 +1045,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1142,7 +1152,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1158,7 +1168,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1245,7 +1255,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -1291,7 +1301,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zvariant_utils",
 ]
 
@@ -1304,6 +1314,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.117",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ uuid = { version = "1", features = ["v4"] }
 thiserror = "2.0.17"
 strum = { version = "0.28.0", features = ["derive"] }
 futures-lite = "2.6.1"
-async-lock = { version = "3.4.2", default-features = false }
 
 [dev-dependencies]
 clap = { version = "4.5.48", features = ["derive"] }

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,15 +8,10 @@ use crate::{
     known_network::KnownNetwork,
     station::{Station, StationDiagnostics},
 };
-use futures_lite::{FutureExt, StreamExt};
-use std::{collections::HashMap, future};
+use std::collections::HashMap;
 use uuid::Uuid;
 use zbus::{
-    Connection, Proxy,
-    fdo::{
-        InterfacesAddedArgs, InterfacesAddedStream, InterfacesRemovedStream, ObjectManagerProxy,
-    },
-    names::OwnedInterfaceName,
+    Connection, fdo::ObjectManagerProxy, names::OwnedInterfaceName, proxy::CacheProperties,
 };
 use zvariant::{OwnedObjectPath, OwnedValue};
 
@@ -26,47 +21,45 @@ type OwnedInterfaceMap = HashMap<OwnedInterfaceName, OwnedPropertiesMap>;
 #[derive(Debug)]
 pub struct Session {
     connection: Connection,
-    _object_manager: ObjectManagerProxy<'static>,
-    cache: async_lock::Mutex<ObjectCache>,
+    object_manager: ObjectManagerProxy<'static>,
 }
 
 impl Session {
     pub async fn new() -> zbus::Result<Self> {
         let connection = Connection::system().await?;
 
-        let proxy = Proxy::new_owned(
-            connection.clone(),
-            "net.connman.iwd",
-            "/",
-            "org.freedesktop.DBus.ObjectManager",
-        )
-        .await?;
-        let object_manager = ObjectManagerProxy::from(proxy);
-
-        let objects: HashMap<OwnedObjectPath, OwnedInterfaceMap> =
-            object_manager.get_managed_objects().await?;
-        let interfaces_added = object_manager.receive_interfaces_added().await?;
-        let interfaces_removed = object_manager.receive_interfaces_removed().await?;
+        let object_manager = ObjectManagerProxy::builder(&connection)
+            .destination("net.connman.iwd")?
+            .path("/")?
+            .cache_properties(CacheProperties::No)
+            .build()
+            .await?;
 
         Ok(Self {
             connection,
-            _object_manager: object_manager,
-            cache: async_lock::Mutex::new(ObjectCache {
-                interfaces_added,
-                interfaces_removed,
-                objects,
-            }),
+            object_manager,
         })
+    }
+
+    async fn managed_objects(&self) -> zbus::Result<HashMap<OwnedObjectPath, OwnedInterfaceMap>> {
+        Ok(self.object_manager.get_managed_objects().await?)
     }
 
     async fn collect_interface<Output: iwd_interface::IwdInterface>(
         &self,
     ) -> zbus::Result<Vec<Output>> {
-        let mut cache = self.cache.lock().await;
-        cache.update_objects_cache().await?;
+        let objects = self.managed_objects().await?;
 
-        let paths: Vec<_> = cache.object_type(Output::INTERFACE).into_iter().collect();
-        let mut results = Vec::with_capacity(paths.len());
+        let paths = objects
+            .into_iter()
+            .filter(|(_, interfaces)| {
+                interfaces
+                    .keys()
+                    .any(|interface| interface.as_str() == Output::INTERFACE)
+            })
+            .map(|(path, _)| path);
+
+        let mut results = Vec::new();
         for path in paths {
             results.push(Output::new(self.connection.clone(), path).await?);
         }
@@ -113,63 +106,5 @@ impl Session {
 
     pub async fn known_networks(&self) -> zbus::Result<Vec<KnownNetwork>> {
         self.collect_interface().await
-    }
-}
-
-#[derive(Debug)]
-struct ObjectCache {
-    interfaces_added: InterfacesAddedStream,
-    interfaces_removed: InterfacesRemovedStream,
-    objects: HashMap<OwnedObjectPath, OwnedInterfaceMap>,
-}
-
-impl ObjectCache {
-    fn object_type(
-        &self,
-        interface_type: &'static str,
-    ) -> impl IntoIterator<Item = OwnedObjectPath> {
-        self.objects.iter().flat_map(move |(path, interfaces)| {
-            let path = path.clone();
-            interfaces
-                .iter()
-                .filter(move |(interface, _)| interface.as_str() == interface_type)
-                .map(move |_| path.clone())
-        })
-    }
-
-    async fn update_objects_cache(&mut self) -> zbus::Result<()> {
-        while let Some(removal) = self.interfaces_removed.next().or(future::ready(None)).await {
-            let args = removal.args()?;
-            self.objects.remove(args.object_path());
-        }
-
-        while let Some(added) = self.interfaces_added.next().or(future::ready(None)).await {
-            let args = added.args()?;
-            let InterfacesAddedArgs {
-                object_path,
-                interfaces_and_properties,
-                ..
-            } = args;
-            let object_path: OwnedObjectPath = object_path.into_owned().into();
-            let interfaces_and_properties: OwnedInterfaceMap = interfaces_and_properties
-                .into_iter()
-                .map(|(iface, props)| {
-                    let iface = iface.into_owned().into();
-                    let props: OwnedPropertiesMap = props
-                        .into_iter()
-                        .filter_map(|(key, val)| {
-                            let Ok(val) = val.try_into_owned() else {
-                                return None;
-                            };
-                            Some((key.to_string(), val))
-                        })
-                        .collect();
-                    (iface, props)
-                })
-                .collect();
-            self.objects.insert(object_path, interfaces_and_properties);
-        }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
The object manager cache was causing all sorts of issues (e.g https://github.com/pythops/iwdrs/pull/25#issuecomment-5627189460). There are also race conditions, we run into an issue where `Interface{Added/Removed}Stream`  fill up (zbus only stores up to 50 events). I think the #24 approach was a mistake and we should have gone with #23. (My bad for proposing it) This implementation is a slight cleanup of #23.